### PR TITLE
Make Twitch::createResourceOwner compatible with parent

### DIFF
--- a/src/Entity/TwitchUser.php
+++ b/src/Entity/TwitchUser.php
@@ -1,16 +1,18 @@
 <?php namespace Depotwarehouse\OAuth2\Client\Twitch\Entity;
 
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+
 /**
  * Class TwitchUser
  * @package Depotwarehouse\OAuth2\Client\Twitch\Entity
  */
-class TwitchUser
+class TwitchUser implements ResourceOwnerInterface
 {
     /**
      * @var string
      */
     protected $name;
-    
+
     /**
      * @var string
      */
@@ -50,7 +52,7 @@ class TwitchUser
      */
     public function __construct(array $attributes = array())
     {
-        $this->id = $attributes['_id'];
+        $this->id = (int) $attributes['_id'];
         $this->display_name = $attributes['display_name'];
         $this->type = $attributes['type'];
         $this->bio = $attributes['bio'];


### PR DESCRIPTION
Fixes tpavlek/oauth2-twitch#12

Also coerces `\Depotwarehouse\OAuth2\Client\Twitch\Entity\TwitchUser::$id` to int for getId.