### PR TITLE
Fix package name to match the one registered on Packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "tpavlek/oauth2-twitch",
+    "name": "depotwarehouse/oauth2-twitch",
     "description": "A Twitch provider for league/oauth2-client",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Not sure how it works, but somehow the package name registered on Packagist is `depotwarehouse/oauth2-twitch`: https://packagist.org/packages/depotwarehouse/oauth2-twitch . Packagist know nothing about `tpavlek/oauth2-twitch`: https://packagist.org/search/?q=tpavlek/oauth2-twitch&reason=package_not_found

Please, double-check the package name in composer.json, I think it should be changed to what I suggested to match Packagist